### PR TITLE
UI Zoom using hotkeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ splash.xcf
 cdprogs/windows/
 cdprogs/mac/
 cdprogs/linux/
+
+# macos
+.DS_Store

--- a/Global/config_handler.gd
+++ b/Global/config_handler.gd
@@ -19,6 +19,7 @@ func _ready():
 	ensure_setting("interface_settings", "theme_custom_colour", "#865699")
 	ensure_setting("interface_settings", "delete_intermediate", true)
 	ensure_setting("interface_settings", "reuse_output_folder", true)
+	ensure_setting("interface_settings", "ui_scale", 1.0)
 	ensure_setting("interface_settings", "autoplay", true)
 	ensure_setting("audio_settings", "device", "Default")
 

--- a/scenes/main/scripts/settings.gd
+++ b/scenes/main/scripts/settings.gd
@@ -3,6 +3,11 @@ signal open_cdp_location
 signal console_on_top
 var interface_settings
 
+# helper to format a float to 2 decimal places without using round(x, ndigits)
+func _format_two_decimals(v: float) -> String:
+	var scaled = float(int(v * 100.0 + 0.5)) / 100.0
+	return str(scaled)
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass
@@ -25,6 +30,11 @@ func _on_about_to_popup() -> void:
 	$VBoxContainer/HBoxContainer6/ProgressBar.button_pressed = interface_settings.disable_progress_bar
 	$VBoxContainer/HBoxContainer3/AutoCloseConsole.button_pressed = interface_settings.auto_close_console
 	$VBoxContainer/HBoxContainer4/ConsoleAlwaysOnTop.button_pressed = interface_settings.console_on_top
+	# ui scale control (added for hidpi/manual scaling)
+	if interface_settings.has("ui_scale"):
+		$VBoxContainer/HBoxContainer7/UIScaleLabel.text = str(interface_settings.ui_scale)
+	else:
+		$VBoxContainer/HBoxContainer7/UIScaleLabel.text = "1.0"
 	
 
 func _on_pvoc_warning_toggled(toggled_on: bool) -> void:
@@ -55,6 +65,27 @@ func _on_theme_list_item_selected(index: int) -> void:
 			RenderingServer.set_default_clear_color(Color("#98d4d2"))
 		3:
 			RenderingServer.set_default_clear_color(Color(interface_settings.theme_custom_colour))
+
+func _on_ui_scale_decrease_button_down() -> void:
+	var v = float($VBoxContainer/HBoxContainer7/UIScaleLabel.text)
+	v = clamp(v - 0.1, 0.5, 4.0)
+	$VBoxContainer/HBoxContainer7/UIScaleLabel.text = _format_two_decimals(v)
+
+	ConfigHandler.save_interface_settings("ui_scale", v)
+	# inform main control to reapply
+	get_tree().get_root().call_deferred("apply_user_ui_scale")
+
+func _on_ui_scale_increase_button_down() -> void:
+	var v = float($VBoxContainer/HBoxContainer7/UIScaleLabel.text)
+	v = clamp(v + 0.1, 0.5, 4.0)
+	$VBoxContainer/HBoxContainer7/UIScaleLabel.text = _format_two_decimals(v)
+	ConfigHandler.save_interface_settings("ui_scale", v)
+	get_tree().get_root().call_deferred("apply_user_ui_scale")
+
+func _on_ui_scale_reset_button_down() -> void:
+	$VBoxContainer/HBoxContainer7/UIScaleLabel.text = "1.0"
+	ConfigHandler.save_interface_settings("ui_scale", 1.0)
+	get_tree().get_root().call_deferred("apply_user_ui_scale")
 
 
 func _on_custom_colour_picker_color_changed(color: Color) -> void:


### PR DESCRIPTION
I faced the same issues described in https://github.com/j-p-higgins/SoundThread/issues/107 and wanted to take a stab at addressing the issue.


It's working for me on macos but I'm not 100% confident on the approach. Full disclosure is that I used AI to help me arrive at the solution so apologies if its total slop. 

To test the new feature, just run the app and use the following hotkeys to zoom in/out and rest the GUI:
- **Ctrl or Cmd +/-** to zoom in/out
- **Ctrl or Cmd 0** to reset zoom back to default
- the setting is also stored for when the user reopens the app

Note: I added both `KEY_PLUS`/`KEY_EQUAL` and both `ctrl` and `meta` to cover keyboards where `+` is a shifted `=` and both `Ctrl` (Windows/Linux) and `Command`/`Meta` (macOS) modifiers, so the shortcuts _should_ work across OSes and different keyboard layouts/devices.

# Demo
![2025-08-24 11 05 32](https://github.com/user-attachments/assets/e88af1fd-73ca-4223-aaef-77f7321049c2)
I noticed that when going back to the default (Ctrl 0) after zooming out, we get a different position to the original layout so the user must drag things back into view. I am not sure how easy that is to solve but can take a look if you think that's too annoying. 
